### PR TITLE
fix(#7787): Added userInsensitive for comparrison checks in dbAuth

### DIFF
--- a/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
+++ b/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
@@ -170,6 +170,7 @@ export interface DbAuthHandlerOptions<TUser = Record<string | number, any>> {
   authFields: {
     id: string
     username: string
+    usernameInsensitive: string
     hashedPassword: string
     salt: string
     resetToken: string
@@ -216,6 +217,7 @@ export interface DbAuthHandlerOptions<TUser = Record<string | number, any>> {
 
 interface SignupHandlerOptions {
   username: string
+  usernameInsensitive: string
   hashedPassword: string
   salt: string
   userAttributes?: Record<string, string>
@@ -468,7 +470,7 @@ export class DbAuthHandler<
 
     try {
       user = await this.dbAccessor.findUnique({
-        where: { [this.options.authFields.username]: username },
+        where: { [this.options.authFields.usernameInsensitive]: username.toLowerCase() },
       })
     } catch (e) {
       throw new DbAuthError.GenericError()
@@ -1213,7 +1215,7 @@ export class DbAuthHandler<
     try {
       // does user exist?
       user = await this.dbAccessor.findUnique({
-        where: { [this.options.authFields.username]: username },
+        where: { [this.options.authFields.usernameInsensitive]: username.toLowerCase() },
       })
     } catch (e) {
       throw new DbAuthError.GenericError()
@@ -1282,8 +1284,9 @@ export class DbAuthHandler<
       this._validateField('username', username) &&
       this._validateField('password', password)
     ) {
+      const usernameInsensitive = username.toLowerCase()
       const user = await this.dbAccessor.findUnique({
-        where: { [this.options.authFields.username]: username },
+        where: { [this.options.authFields.usernameInsensitive]: usernameInsensitive },
       })
       if (user) {
         throw new DbAuthError.DuplicateUsernameError(
@@ -1294,9 +1297,12 @@ export class DbAuthHandler<
 
       // if we get here everything is good, call the app's signup handler and let
       // them worry about scrubbing data and saving to the DB
+      // We are storing both a username and usernameInsenitive so that we retain the pretty formatted version
+      // the user is expecting to see but use the usernameInsensitive for comparrison checking.
       const [hashedPassword, salt] = hashPassword(password)
       const newUser = await (this.options.signup as SignupFlowOptions).handler({
         username,
+        usernameInsensitive,
         hashedPassword,
         salt,
         userAttributes,

--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
@@ -1,4 +1,5 @@
 import CryptoJS from 'crypto-js'
+import { M } from 'msw/lib/glossary-de6278a9'
 
 import { DbAuthHandler } from '../DbAuthHandler'
 import * as dbAuthError from '../errors'
@@ -83,9 +84,11 @@ const UTC_DATE_REGEX = /\w{3}, \d{2} \w{3} \d{4} [\d:]{8} GMT/
 const LOGOUT_COOKIE = 'session=;Expires=Thu, 01 Jan 1970 00:00:00 GMT'
 
 const createDbUser = async (attributes = {}) => {
+  const email = "roB@redWoodjs.com";
   return await db.user.create({
     data: {
-      email: 'rob@redwoodjs.com',
+      email,
+      emailInsensitive: email.toLocaleLowerCase(),
       hashedPassword:
         '0c2b24e20ee76a887eac1415cc2c175ff961e7a0f057cead74789c43399dd5ba',
       salt: '2ef27f4073c603ba8b7807c6de6d6a89',
@@ -129,6 +132,7 @@ describe('dbAuth', () => {
       authFields: {
         id: 'id',
         username: 'email',
+        usernameInsensitive: 'emailInsensitive',
         hashedPassword: 'hashedPassword',
         salt: 'salt',
         resetToken: 'resetToken',
@@ -159,6 +163,7 @@ describe('dbAuth', () => {
           return db.user.create({
             data: {
               email: username,
+              emailInsensitive: username.toLowerCase(),
               hashedPassword: hashedPassword,
               salt: salt,
               name: userAttributes.name,


### PR DESCRIPTION
For #7787

# What it does:
Fixes an issue in the dbAuth user validation where the check is not case insensitive. This would result in duplicate users if they had different casing.

